### PR TITLE
Support new nodejs environments for -a flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ module.exports = function(S) {
       // user passed the --all option
       if (options.all) {
         return S.getProject().getAllFunctions().filter(function(func) {
-          return func.runtime === 'nodejs';
+          return func.runtime.substring(0, 6) === 'nodejs';
         });
       }
 
@@ -78,7 +78,7 @@ module.exports = function(S) {
       // will return all functions if none in cwd
       if (S.cli && names.length === 0) {
         return S.utils.getFunctionsByCwd(S.getProject().getAllFunctions()).filter(function(func) {
-          return func.runtime === 'nodejs';
+          return func.runtime.substring(0, 6) === 'nodejs';
         });
       }
 


### PR DESCRIPTION
Support for new nodejs environments was added in https://github.com/joostfarla/serverless-jshint-plugin/pull/4. However it didn't cover -a / --all flag. This PR adds support for nodejs environments in detecting Serverless functions (in --all flag). It copies the same solution from previous PR to the other line.
